### PR TITLE
add "foreign_key" (optional) key for form_sub.

### DIFF
--- a/resources/views/admin/default/form.blade.php
+++ b/resources/views/admin/default/form.blade.php
@@ -151,7 +151,7 @@
       $table = str_replace("_view", "", $table);
 			$c = new $fs['classname'];
 			$c->parent_id 		 = $row->id;
-			$c->parent_field	 = 'id_'.$table;
+			$c->parent_field = !empty($fs['foreign_key']) ? $fs['foreign_key'] : 'id_'.$table;
 			$c->controller_name  = str_replace("App\Http\Controllers\\","",strtok($fs['classname'],'@') );
 			$c->index_table_only = true;
 			$c->table_name       = $fs['label'];


### PR DESCRIPTION
mungkin utk merubah foreign key pada form_sub agar lebih dinamis tidak harus id_namatable. 
karna setau saya default laravel menggunakan **namatable_id** utk foreign key seperti **user_id**.

`$this->form_sub[] = array('Label' => 'Article', 'controller' => 'ArticleController', 'foreign_key' => 'category_id' );
        `