### PR TITLE
allow html code in indexs

### DIFF
--- a/src/controllers/CBController.php
+++ b/src/controllers/CBController.php
@@ -57,6 +57,8 @@ class CBController extends Controller {
 
 	public $index_statistic       = array();
 	public $index_additional_view = array();
+	public $pre_index_html        = null;
+	public $post_index_html       = null;
 	public $load_js               = array();
 	public $load_css              = array();
 	public $script_js             = NULL;
@@ -104,6 +106,8 @@ class CBController extends Controller {
 		$this->data['index_statistic']       = $this->index_statistic;
 		$this->data['index_additional_view'] = $this->index_additional_view;
 		$this->data['table_row_color']       = $this->table_row_color;
+		$this->data['pre_index_html']        = $this->pre_index_html;
+		$this->data['post_index_html']       = $this->post_index_html;
 		$this->data['load_js']               = $this->load_js;
 		$this->data['load_css']              = $this->load_css;
 		$this->data['script_js']             = $this->script_js;

--- a/src/helpers/CRUDBooster.php
+++ b/src/helpers/CRUDBooster.php
@@ -1333,7 +1333,30 @@ class CRUDBooster  {
 	        $this->script_js = NULL;
 
 
-
+            /*
+	        | ---------------------------------------------------------------------- 
+	        | Include HTML Code before index table 
+	        | ---------------------------------------------------------------------- 
+	        | html code to display it before index table
+	        | $this->pre_index_html = "<p>test</p>";
+	        |
+	        */
+	        $this->pre_index_html = null;
+	        
+	        
+	        
+	        /*
+	        | ---------------------------------------------------------------------- 
+	        | Include HTML Code after index table 
+	        | ---------------------------------------------------------------------- 
+	        | html code to display it after index table
+	        | $this->post_index_html = "<p>test</p>";
+	        |
+	        */
+	        $this->post_index_html = null;
+	        
+	        
+	        
 	        /*
 	        | ---------------------------------------------------------------------- 
 	        | Include Javascript File 

--- a/src/views/default/index.blade.php
+++ b/src/views/default/index.blade.php
@@ -20,6 +20,10 @@
       </div>
     @endif
 
+   @if(!is_null($pre_index_html) && !empty($pre_index_html))
+       {!! $pre_index_html !!}
+   @endif
+
 
     @if(g('return_url'))
     <p><a href='{{g("return_url")}}'><i class='fa fa-chevron-circle-{{ trans('crudbooster.left') }}'></i> &nbsp; {{trans('crudbooster.form_back_to_list',['module'=>ucwords(str_replace('_',' ',g('parent_table')))])}}</a></p>
@@ -113,6 +117,9 @@
         @include("crudbooster::default.table")
       </div>
     </div>
-    
+
+   @if(!is_null($post_index_html) && !empty($post_index_html))
+       {!! $post_index_html !!}
+   @endif
 
 @endsection


### PR DESCRIPTION
allow to add HTML code in the index list before and after the table.

its can be used to show some text (not alert) or some html codes or special links ... etc 

Example : 
![screen shot 2017-03-15 at 12 01 51 am](https://cloud.githubusercontent.com/assets/1952412/23922516/bdc59a6e-0913-11e7-8c32-e02946efb473.png)

I add two options : `pre_index_html` , `post_index_html` and its null by default , to be used in `cbInit()` like : 

```
$this->pre_index_html = "
            <div style='margin: 5px; padding: 10px; border: solid 1px darkgrey'>
                Quick status filter :
                <select name=\"limit\" style=\"width: 200px;\" class=\"form-control input-sm\">
                    <option>status 1</option>
                    <option>status 2</option>
                    <option>status 3</option>
                </select>
                
            </div>
        ";
```

I hope you find it useful 

thank you .