### PR TITLE
Add Default Option for Select Type

### DIFF
--- a/src/views/default/type_components/select/component.blade.php
+++ b/src/views/default/type_components/select/component.blade.php
@@ -1,3 +1,4 @@
+	<?php $default = !empty($form['default']) ? $form['default'] : trans('crudbooster.text_prefix_option') ." ". $form['label'];?>
 	@if($form['parent_select'])
 	<script type="text/javascript">
 		$(function() {			
@@ -15,7 +16,7 @@
 					$current.html("<option value=''>{{trans('crudbooster.text_loading')}} {{$form['label']}}");
 					$.get("{{CRUDBooster::mainpath('data-table')}}?table="+table+"&label="+label+"&fk_name="+fk_name+"&fk_value="+fk_value,function(response) {
 						if(response) {
-							$current.html("<option value=''>{{trans('crudbooster.text_prefix_option')}} {{$form['label']}}");
+							$current.html("<option value=''>{{$default}}");
 							$.each(response,function(i,obj) {
 								var selected = (value && value == obj.select_value)?"selected":"";
 								$("<option "+selected+" value='"+obj.select_value+"'>"+obj.select_label+"</option>").appendTo("#{{$form['name']}}");
@@ -24,7 +25,7 @@
 						}						
 					});
 				}else{
-					$current.html("<option value=''>{{trans('crudbooster.text_prefix_option')}} {{$form['label']}}");
+					$current.html("<option value=''>{{$default}}");
 				}								
 			})
 
@@ -38,7 +39,7 @@
 
 		<div class="{{$col_width?:'col-sm-10'}}">									
 		<select class='form-control' id="{{$name}}" data-value='{{$value}}' {{$required}} {!!$placeholder!!} {{$readonly}} {{$disabled}} name="{{$name}}">
-			<option value=''>{{trans('crudbooster.text_prefix_option')}} {{$form['label']}}</option>
+			<option value=''>{{$default}}</option>
 			<?php 	
 				if(!$form['parent_select']) {
 					if(@$form['dataquery']):


### PR DESCRIPTION
The default option "** Please select a [Label]" sometimes doesn't make sense, for example labels like "Employee,  Article, etc" it should be  "Please select an ...". This change, will let developers override default option by setting the 'default' property. If 'default' property is not set, it will default to the lang:text_prefix_option, as it is now.

Usage Example:
        $this->form[] = [
            'label'      => 'Assign To',
            'name'       => 'assign_to',
            'type'       => 'select',
            'validation' => 'required',
            'width'      => 'col-sm-4',
            'default'    => 'Select Employee Name',
            "dataquery"  => 'select id as value,name as label from cms_users',
        ];