### PR TITLE
Fix Child Radio Type Error

### DIFF
--- a/src/views/default/type_components/child/component.blade.php
+++ b/src/views/default/type_components/child/component.blade.php
@@ -37,8 +37,15 @@
 										/>
 									@elseif($col['type']=='radio')
 										<?php 
-											if($col['dataenum']):												
-											foreach($col['dataenum'] as $e=>$enum):
+											if($col['dataenum']):
+                                            $dataenum = $col['dataenum'];
+                                            if(strpos($dataenum, ';') !== false) {
+                                                $dataenum = explode(";", $dataenum);
+                                            } else {
+                                                $dataenum = [$dataenum];
+                                            }
+                                            array_walk($dataenum, 'trim');
+											foreach($dataenum as $e=>$enum):
 												$enum = explode('|',$enum);
 												if(count($enum)==2) {
 													$radio_value = $enum[0];

--- a/src/views/default/type_components/select/info.json
+++ b/src/views/default/type_components/select/info.json
@@ -12,7 +12,8 @@
 			"help":"string help-block",
 			"datatable_where":"string where condition",		
 			"datatable_format":"sql concat alike. e.g : id,' - ',title",					
-			"parent_select":"string parent name"
+			"parent_select":"string parent name",
+			"default":"string default option"
 		}								
 	}
 }


### PR DESCRIPTION
The current code is throwing an error when you trying to add a radio in a child form, since is trying to loop 'dataenum' before exploding it.This new code checks if 'dataenum' is explodable and if it is not it will create an array of the string so it will trim and loop with no errors.