### PR TITLE
Add error notification capability for ActionButtonSelected

### DIFF
--- a/src/controllers/CBController.php
+++ b/src/controllers/CBController.php
@@ -1541,12 +1541,17 @@ class CBController extends Controller {
 			return redirect()->back()->with(['message_type'=>'success','message'=>$message]);
 		}
 
-		$this->actionButtonSelected($id_selected,$button_name);
+        if($this->actionButtonSelected($id_selected,$button_name) === false) {
+            $message = !empty($this->alert['message']) ? $this->alert['message'] : 'Error';
+            $type = !empty($this->alert['type']) ? $this->alert['type'] : 'danger';
+        } else {
+            $action = str_replace(['-','_'],' ',$button_name);
+            $action = ucwords($action);
+            $type = 'success';
+            $message = trans("crudbooster.alert_action",['action'=>$action]);
 
-		$action = str_replace(['-','_'],' ',$button_name);
-		$action = ucwords($action);
-		$message = trans("crudbooster.alert_action",['action'=>$action]);
-		return redirect()->back()->with(['message_type'=>'success','message'=>$message]);
+        }
+        return redirect()->back()->with(['message_type'=>$type,'message'=>$message]);
 	}
 
 	public function getDeleteImage() {


### PR DESCRIPTION
When you return false on "actionButtonSelected", it will display a custom notification and a custom message. If it returns something else than false it will works as it is now. 

Now, it always displays: "You have :action successfully !" with an "alert-success" notification 

Usage:
    public function actionButtonSelected($id_selected, $button_name) {
            // Set custom Message and Custom Alert Type
            $this->alert = ['message' => 'Please choose at least one sale.', 'type' => 'danger'];
            // Return false
            return false;
    }