### PR TITLE
change form name in child form to avoid conflict with parent form

### DIFF
--- a/src/views/default/type_components/child/component.blade.php
+++ b/src/views/default/type_components/child/component.blade.php
@@ -34,7 +34,7 @@
 								@endif
 								<div class="col-sm-10">
 									@if($col['type']=='text')
-									<input id='{{$name_column}}' type='text' {{ ($col['max'])?"maxlength='$col[max]'":"" }} name='{{$col["name"]}}' class='form-control {{$col['required']?"required":""}}' 										
+									<input id='{{$name_column}}' type='text' {{ ($col['max'])?"maxlength='$col[max]'":"" }} name='child-{{$col["name"]}}' class='form-control {{$col['required']?"required":""}}' 										
 										{{($col['readonly']===true)?"readonly":""}} 
 										/>
 									@elseif($col['type']=='radio')
@@ -57,7 +57,7 @@
 												}
 										?>
 										<label class="radio-inline">
-										  <input type="radio" name="{{$col['name']}}" class='{{ ($e==0 && $col['required'])?"required":""}} {{$name_column}}'  value="{{$radio_value}}"> {{$radio_label}} 
+										  <input type="radio" name="child-{{$col['name']}}" class='{{ ($e==0 && $col['required'])?"required":""}} {{$name_column}}'  value="{{$radio_value}}"> {{$radio_label}} 
 										</label>
 										<?php endforeach;?>
 										<?php endif;?>
@@ -118,11 +118,11 @@
 									</div><!-- /.modal -->
 
 									@elseif($col['type']=='number')
-									<input id='{{$name_column}}' type='number' {{ ($col['min'])?"min='$col[min]'":"" }} {{ ($col['max'])?"max='$col[max]'":"" }} name='{{$col["name"]}}' class='form-control {{$col['required']?"required":""}}' 										
+									<input id='{{$name_column}}' type='number' {{ ($col['min'])?"min='$col[min]'":"" }} {{ ($col['max'])?"max='$col[max]'":"" }} name='child-{{$col["name"]}}' class='form-control {{$col['required']?"required":""}}' 										
 										{{($col['readonly']===true)?"readonly":""}} 
 										/>
 									@elseif($col['type']=='textarea')		
-									<textarea id='{{$name_column}}' name='{{$col["name"]}}' class='form-control {{$col['required']?"required":""}}' {{($col['readonly']===true)?"readonly":""}} ></textarea>
+									<textarea id='{{$name_column}}' name='child-{{$col["name"]}}' class='form-control {{$col['required']?"required":""}}' {{($col['readonly']===true)?"readonly":""}} ></textarea>
 									@elseif($col['type']=='upload')
 									<div id='{{$name_column}}' class="input-group">
 									  <input type="hidden" class="input-id">
@@ -245,7 +245,7 @@
 								    @endpush
 
 									@elseif($col['type']=='select')
-									<select id='{{$name_column}}' name='{{$col["name"]}}' class='form-control select2 {{$col['required']?"required":""}}' 										
+									<select id='{{$name_column}}' name='child-{{$col["name"]}}' class='form-control select2 {{$col['required']?"required":""}}' 										
 										{{($col['readonly']===true)?"readonly":""}} 
 										>
 										<option value=''>{{trans('crudbooster.text_prefix_option')}} {{$col['label']}}</option>
@@ -277,7 +277,7 @@
 										?>										
 									</select>
 									@elseif($col['type']=='hidden')
-										<input type="{{$col['type']}}" id="{{$name.$col["name"]}}" name="{{$name.$col["name"]}}" value="{{$col["value"]}}">
+										<input type="{{$col['type']}}" id="{{$name.$col["name"]}}" name="child-{{$name.$col["name"]}}" value="{{$col["value"]}}">
 									@endif
 
 									@if($col['help']) 


### PR DESCRIPTION
let say I have table product (parent) and productitems (child), both has name column.
when I want to edit the record of one product and save button pushed, name of the product will be discarded, because has same "name" input with child form.
the last column order value (child) will be post instead of parent.

<img width="400" alt="screen shot 2017-07-09 at 12 15 39 am" src="https://user-images.githubusercontent.com/446747/27987719-609e3f2e-643c-11e7-93fa-39c277611229.png">

i'm proposing to alter name in child form to 
`name='child-{{$col["name"]}}'`
since when child form 'Add To Table' button pushed only consider id/class and not name.
`value='"+$('#{{$name.$c["name"]}}').val()+"'`

