### PR TITLE
Add pre-checking for some custom validation if needed before execute API

### DIFF
--- a/docs/en/how-to-put-custom-condition-grid-data.md
+++ b/docs/en/how-to-put-custom-condition-grid-data.md
@@ -32,7 +32,7 @@ public function hook_query_index(&$query) {
 ```
 
 ## What's Next
-- [How To Inject A Post Data In Create/Update/Delete Data Process](./how-to-inject-postdata.md)
+- [How To Validate API Request](./how-to-validate-api-request.md)
 
 ## Table Of Contents
 - [Back To Index](./index.md)

--- a/docs/en/how-to-validate-api-request.md
+++ b/docs/en/how-to-validate-api-request.md
@@ -1,0 +1,32 @@
+### How To Validate API Request
+
+In some case you need to make a pre-checking before executing API
+
+CRUDBooster provide the method that you can use to do some validation before executing API
+
+```php
+public function hook_discard_api(&$postdata) {
+    //Your any custom pre-checking
+}
+```
+This special method come in API controller that you've genereated.
+
+For example, you want to add user into cms_users through API and want to validate whether email already registered or not
+
+```php
+public function hook_discard_api(&$postdata) {
+    $email = $postdata['email'];
+    $checkmail = DB::table('cms_users')->where('email',$email)->first();;
+
+    if($checkmail) {
+      $this->hook_api_message = 'Email already registered!';
+      $this->discard_api = true;
+    }
+}
+```
+
+## What's Next
+- [How To Inject A Post Data In Create/Update/Delete Data Process](./how-to-inject-postdata.md)
+
+## Table Of Contents
+- [Back To Index](./index.md)

--- a/docs/en/how-to-validate-api-request.md
+++ b/docs/en/how-to-validate-api-request.md
@@ -5,7 +5,7 @@ In some case you need to make a pre-checking before executing API
 CRUDBooster provide the method that you can use to do some validation before executing API
 
 ```php
-public function hook_discard_api(&$postdata) {
+public function hook_validate(&$postdata) {
     //Your any custom pre-checking
 }
 ```
@@ -14,13 +14,13 @@ This special method come in API controller that you've genereated.
 For example, you want to add user into cms_users through API and want to validate whether email already registered or not
 
 ```php
-public function hook_discard_api(&$postdata) {
+public function hook_validate(&$postdata) {
     $email = $postdata['email'];
     $checkmail = DB::table('cms_users')->where('email',$email)->first();;
 
     if($checkmail) {
       $this->hook_api_message = 'Email already registered!';
-      $this->discard_api = true;
+      $this->validate = true;
     }
 }
 ```

--- a/src/controllers/ApiController.php
+++ b/src/controllers/ApiController.php
@@ -19,7 +19,8 @@ class ApiController extends Controller {
 	var $permalink;
 	var $hook_api_status;
 	var $hook_api_message;	
-	var $last_id_tmp       = array();
+	var $discard_api = false;
+	var $last_id_tmp = array();
 	
 
 	public function hook_before(&$postdata) {
@@ -27,6 +28,10 @@ class ApiController extends Controller {
 	}
 	public function hook_after($postdata,&$result) {
 		
+	}
+
+	public function hook_discard_api(&$postdata) {
+
 	}
 
 	public function hook_query(&$query) {
@@ -54,6 +59,19 @@ class ApiController extends Controller {
 		$table                    = $row_api->tabel;
 
 		$debug_mode_message = 'You are in debug mode !';
+
+		/* 
+		| ----------------------------------------------
+		| Do some custome pre-checking for posted data, if failed discard API execution
+		| ----------------------------------------------
+		|
+		*/
+		$this->hook_discard_api($posts);
+		if($this->discard_api) { // hook have to return true
+			$result['api_status']  = 0;
+			$result['api_message'] = "Failed to execute API !";
+			goto show;
+		}
 
 		/* 
 		| ----------------------------------------------

--- a/src/controllers/ApiController.php
+++ b/src/controllers/ApiController.php
@@ -19,7 +19,7 @@ class ApiController extends Controller {
 	var $permalink;
 	var $hook_api_status;
 	var $hook_api_message;	
-	var $discard_api = false;
+	var $validate = false;
 	var $last_id_tmp = array();
 	
 
@@ -30,7 +30,7 @@ class ApiController extends Controller {
 		
 	}
 
-	public function hook_discard_api(&$postdata) {
+	public function hook_validate(&$postdata) {
 
 	}
 
@@ -66,8 +66,8 @@ class ApiController extends Controller {
 		| ----------------------------------------------
 		|
 		*/
-		$this->hook_discard_api($posts);
-		if($this->discard_api) { // hook have to return true
+		$this->hook_validate($posts);
+		if($this->validate) { // hook have to return true
 			$result['api_status']  = 0;
 			$result['api_message'] = "Failed to execute API !";
 			goto show;


### PR DESCRIPTION
This is tend to add custom pre-checking/validation before executing API if needed.
If checking not pass then set 
`$this->discard_api = true;`
and send the message
`$this->hook_api_message = 'Some message why not pass!';`