### PR TITLE
fix form type money parameter

### DIFF
--- a/docs/en/form-money.md
+++ b/docs/en/form-money.md
@@ -5,6 +5,12 @@ Input text with auto money number format
 ```php
 $this->form[] = ['label'=>'Price','name'=>'price','type'=>'money'];
 ```
+### Custom Money Format
+```php
+$this->form[] = ['label'=>'Price','name'=>'price','type'=>'money', 'priceformat_parameters' => ['prefix' => 'Rp. ', 'thousandsSeparator' => '.', 'centsSeparator' => ',', 'centsLimit' => 2 ]];
+// Rp. 1.000,00
+```
+Add `priceformat_parameters` attribute value with [JQuery Price Format parameters](http://flaviosilveira.com/Jquery-Price-Format/)
 
 ## What's Next
 - [Form Input Type: number](./form-number.md)

--- a/src/views/default/type_components/money/asset.blade.php
+++ b/src/views/default/type_components/money/asset.blade.php
@@ -1,18 +1,17 @@
 @push('bottom')
 <script>
 	$(function() {
-		$('.inputMoney').priceFormat({
-			prefix: '',
-			@if($form['dec_point'])
-			thousandsSeparator: '{!! $form['dec_point']?: '' !!}',
+		@foreach($forms as $form)
+			@if($form['type'] == $type)				
+				$('.inputMoney#{{ $form['name'] }}').priceFormat({!! json_encode(array_merge(array(
+				            'prefix' 				=> '',
+				            'thousandsSeparator'    => $form['dec_point'] ? : ',',
+				            'centsLimit'          	=> $form['decimals'] ? : '0',
+				            'clearOnEmpty'         	=> false,
+				        ), (array)$form['priceformat_parameters'] 
+					)) !!});
 			@endif
-			@if($form['decimals'])
-			centsLimit: {!! $form['decimals'] !!},
-			@else
-			centsLimit: 0,		
-			@endif
-			clearOnEmpty:true,
-		});
+		@endforeach
 	});
 </script>
 @endpush


### PR DESCRIPTION
[![screenshot_20170912_221657.jpg](https://s26.postimg.org/py0184j6x/screenshot_20170912_221657.jpg)](https://postimg.org/image/yg9hcgpph/)

different money format for each form.

use 'priceformat_parameters' as array in form parameter.
ex. 
```php
$this->form[] = [... 'type'=>'money','priceformat_parameters' => ['prefix' => 'Rp. ', 'thousandsSeparator' => '.', 'centsSeparator' => ',', 'centsLimit' => 2] ...];
```
custom parameter list http://flaviosilveira.com/Jquery-Price-Format/