### PR TITLE
 Showing empty date instead of default date. 

### DIFF
--- a/src/views/default/type_components/date/component_detail.blade.php
+++ b/src/views/default/type_components/date/component_detail.blade.php
@@ -1,1 +1,1 @@
-{{ date("F, d Y", strtotime($value)) }}
+{{ !empty($value) ? date("F, d Y", strtotime($value)) : null }}

--- a/src/views/default/type_components/datetime/component_detail.blade.php
+++ b/src/views/default/type_components/datetime/component_detail.blade.php
@@ -1,1 +1,1 @@
-{{ date("F, d Y H:i", strtotime($value)) }}
+{{ !empty($value) ? date("F, d Y H:i", strtotime($value)) : null }}


### PR DESCRIPTION
With this, no default date/datetime is shown if there's no value for the attribute.

So, you'll see an empty space for null values instead of `December, 31 1969` or `December, 31 1969 19:00`.