### PR TITLE
Fixed #1234

### DIFF
--- a/src/routes.php
+++ b/src/routes.php
@@ -68,7 +68,8 @@ Route::group([
     }
 
     try {
-        $moduls = DB::table('cms_moduls')->where('path', '!=', '')->where('controller', '!=', '')->where('is_protected', 0)->get();
+        $moduls = DB::table('cms_moduls')->where('path', '!=', '')->where('controller', '!=', '')
+            ->where('is_protected', 0)->where('deleted_at', null)->get();
         foreach ($moduls as $v) {
             CRUDBooster::routeController($v->path, $v->controller);
         }


### PR DESCRIPTION
Added `->where('deleted_at', null)` for being able to use `php artisan route:list` after a module is deleted.