### PR TITLE
Fixed annoying options bug in Modul Generator (Step 3)

### DIFF
--- a/src/Modules/ModuleGenerator/views/step3/script.blade.php
+++ b/src/Modules/ModuleGenerator/views/step3/script.blade.php
@@ -132,7 +132,22 @@
     }
 
     $(function () {
-
+        function reassignAllOptionsIndexes(){
+            //reassign all options indexes in name attribute
+            var idx = 0;
+            $('.table-form tbody').find('tr').each(function (i, el) {
+                var $tds = $(this).find('td');
+                //find column options
+                $tds.eq(5).find('.option_area .form-group').each(function (i, el) {
+                    //reassign option index in name attribute of input
+                    var input = $(this).find('input');
+                    var name = input.attr('name');
+                    var lastpiece = input.attr('name').substr(8,name.length);                
+                    input.attr('name','option['+idx+lastpiece);
+                });
+                idx++;
+            });
+         }    
 
         $(document).on('click', '.btn-plus', function () {
             var tr_parent = $(this).parent().parent('tr');
@@ -140,6 +155,7 @@
             clone.removeAttr('id');
             tr_parent.after(clone);
             $('.table-form tr').not('#tr-sample').show();
+            reassignAllOptionsIndexes();
         })
 
 //init row
@@ -179,6 +195,7 @@
 
         $(document).on('click', '.table-form .btn-delete', function () {
             $(this).parent().parent().remove();
+            reassignAllOptionsIndexes();
         })
 
         $(document).on('click', '.table-form .btn-up', function () {
@@ -189,6 +206,7 @@
                 tr.prev('tr').before(tr.clone());
                 tr.remove();
             }
+            reassignAllOptionsIndexes();
         })
 
         $(document).on('click', '.table-form .btn-down', function () {
@@ -199,6 +217,7 @@
                 tr.next('tr').after(tr.clone());
                 tr.remove();
             }
+            reassignAllOptionsIndexes();
         })
 
         var handleOptions = null;


### PR DESCRIPTION
- How should it happen? What was the expected behavior?
When adding, deleting, moving field row in Modul Generator (Step 3), configuration became assigned to wrong index / field after saving step. Option index must be reassigned and reconfigured after managing field row.

- Tell how to reproduce the problem step by step
1. Go to Module Generator (Step 3)
2. Fill options from any field row
3. Save / Next
4. Back to Step 3
5. Add new row before last edited field row / Move last edited row to up or down
6. Save / Next
7. Back to Step 3 and you will see wrong options configuration data are assigned to the wrong row index

**This fix contains function to reassign all options indexes to the correct row after managing the row position**
