### PR TITLE
change sub module url parameter sort to support greater than two levels

### DIFF
--- a/src/controllers/CBController.php
+++ b/src/controllers/CBController.php
@@ -512,7 +512,7 @@ class CBController extends Controller
                 $addaction[] = [
                     'label' => $s['label'],
                     'icon' => $s['button_icon'],
-                    'url' => CRUDBooster::adminPath($s['path']).'?parent_table='.$table_parent.'&parent_columns='.$s['parent_columns'].'&parent_columns_alias='.$s['parent_columns_alias'].'&parent_id=['.(! isset($s['custom_parent_id']) ? "id" : $s['custom_parent_id']).']&return_url='.urlencode(Request::fullUrl()).'&foreign_key='.$s['foreign_key'].'&label='.urlencode($s['label']),
+                    'url' => CRUDBooster::adminPath($s['path']).'?return_url='.urlencode(Request::fullUrl()).'&parent_table='.$table_parent.'&parent_columns='.$s['parent_columns'].'&parent_columns_alias='.$s['parent_columns_alias'].'&parent_id=['.(! isset($s['custom_parent_id']) ? "id" : $s['custom_parent_id']).']&foreign_key='.$s['foreign_key'].'&label='.urlencode($s['label']),
                     'color' => $s['button_color'],
                     'showIf' => $s['showIf'],
                 ];


### PR DESCRIPTION
Because there are more than two levels, the URL parameters will be repeated, causing the correct parameters to be overwritten.
E.g
if this code 
`urlencode(Request::fullUrl())`
get value is 
`https://www.xxx.com/data?parent_table=table&return_url=http://www.xxx.com/list`,
you will find this problem.