### PR TITLE
custom_parent_alias doesn't exist for sub modules.

### DIFF
--- a/docs/en/how-to-make-graded-module.md
+++ b/docs/en/how-to-make-graded-module.md
@@ -33,7 +33,7 @@ $this->sub_module[] = ['label'=>'Photos','path'=>'photos','parent_columns'=>'nam
 | button_color | Specify the color of button (primary,warning,success,info) |
 | button_icon | Specify the icon. You can find out at Font Awesome |
 | custom_parent_id | Specify the id field. |
-| custom_parent_alias | Specify the  field alias. |
+| parent_columns_alias | Specify the  field alias. |
 | showIf | Specify the condition when the sub module must be shown. Use field alias. e.g : [id] == 1. Shown by default. |
 
 ## What's Next


### PR DESCRIPTION
The right name is parent_columns_alias.
https://github.com/crocodic-studio/crudbooster/search?q=parent_columns_alias&unscoped_q=parent_columns_alias