### PR TITLE
Update CBController.php Direct Reference to ID for PHP 7

### DIFF
--- a/src/controllers/CBController.php
+++ b/src/controllers/CBController.php
@@ -1223,7 +1223,7 @@ class CBController extends Controller
                         if(!empty($colvalue)) $column_data[$colname] = $colvalue;
                     }
                     if(!empty($column_data)){
-                        $column_data[$fk] = $id;
+                        $column_data[$fk] = (!empty($id) ? $id : $lastInsertId);
                         $child_array[] = $column_data;
                     }
                 }


### PR DESCRIPTION
Had an issue with Child Forms do not pickup the ID of the foreign KEY after insertion. The logic helps pickup the right ID under the user interaction.