### PR TITLE
Update CBController, Support Post Values

### DIFF
--- a/src/controllers/CBController.php
+++ b/src/controllers/CBController.php
@@ -1220,9 +1220,11 @@ class CBController extends Controller
                     foreach ($columns as $col) {
                         $colname = $col['name'];
                         $colvalue = Request::get($name.'-'.$colname)[$i];
-                        if(!empty($colvalue)) $column_data[$colname] = $colvalue;
+                        if(isset($colvalue) === TRUE) {
+                            $column_data[$colname] = $colvalue;
+                        }
                     }
-                    if(!empty($column_data)){
+                    if(isset($column_data) === TRUE) {
                         $column_data[$fk] = (!empty($id) ? $id : $lastInsertId);
                         $child_array[] = $column_data;
                     }
@@ -1371,9 +1373,11 @@ class CBController extends Controller
                     foreach ($columns as $col) {
                         $colname = $col['name'];
                         $colvalue = Request::get($name.'-'.$colname)[$i];
-                        if(!empty($colvalue)) $column_data[$colname] = $colvalue;
+                        if(isset($colvalue) === TRUE) {
+                            $column_data[$colname] = $colvalue;
+                        }
                     }
-                    if(!empty($column_data)){
+                    if(isset($column_data) === TRUE){
                         $column_data[$childtablePK] = $lastId;
                         $column_data[$fk] = $id;
                         $child_array[] = $column_data;


### PR DESCRIPTION
The insert column counts become offset in cases when you have zero values. Using "empty" failed in conditions when the field is not required. The insert query builder was set to insert the array, which must match column count.  Using "isset" prompts the business logic to gather the value regardless.