### PR TITLE
Fixed issue caused by the new syntax of Process constructor since Laravel 7.0

### DIFF
--- a/src/commands/CrudboosterInstallationCommand.php
+++ b/src/commands/CrudboosterInstallationCommand.php
@@ -49,7 +49,11 @@ class CrudboosterInstallationCommand extends Command
 
             $this->info('Dumping the autoloaded files and reloading all new files...');
             $composer = $this->findComposer();
-            $process = new Process($composer.' dumpautoload');
+
+            $process = (app()->version() >= 7.0)
+                ? new Process([$composer.' dumpautoload'])
+                : new Process($composer.' dumpautoload');
+
             $process->setWorkingDirectory(base_path())->run();
 
             $this->info('Migrating database...');


### PR DESCRIPTION
Laravel 7 upgraded Symphony from 4 to 5 and Process syntax changed.

New usage : 
```
$process = new Process(['ls', '-lsa']);
$process->run();
```