### PR TITLE
Fix form_detail.blade.php

### DIFF
--- a/src/views/default/form_detail.blade.php
+++ b/src/views/default/form_detail.blade.php
@@ -61,8 +61,8 @@ $asset_already[] = $type;
             $join_title = $join_arr[1];
             $join_table_pk = CB::pk($join_table);
             $join_fk = CB::getForeignKey($table, $join_table);
-            $join_query_{$join_table} = DB::table($join_table)->select($join_title)->where($join_table_pk, $row->{$join_fk})->first();
-            $value = @$join_query_{$join_table}->{$join_title};
+            $join_query_[$join_table] = DB::table($join_table)->select($join_title)->where($join_table_pk, $row->{$join_fk})->first();
+            $value = @$join_query_[$join_table]->{$join_title};
         }
 
         $type = @$form['type'] ?: 'text';


### PR DESCRIPTION
ErrorException
Array and string offset access syntax with curly braces is deprecated

PHP 7.3
Laravel 7+
Crudbooster 5.5.*