### PR TITLE
form detail can receive label through query string

### DIFF
--- a/src/views/default/form.blade.php
+++ b/src/views/default/form.blade.php
@@ -6,7 +6,7 @@
         @if(CRUDBooster::getCurrentMethod() != 'getProfile' && $button_cancel)
             @if(g('return_url'))
                 <p><a title='Return' href='{{g("return_url")}}'><i class='fa fa-chevron-circle-left '></i>
-                        &nbsp; {{cbLang("form_back_to_list",['module'=>CRUDBooster::getCurrentModule()->name])}}</a></p>
+                        &nbsp; {{cbLang("form_back_to_list",['module'=>g('return_url_label') ? :CRUDBooster::getCurrentModule()->name])}}</a></p>
             @else
                 <p><a title='Main Module' href='{{CRUDBooster::mainpath()}}'><i class='fa fa-chevron-circle-left '></i>
                         &nbsp; {{cbLang("form_back_to_list",['module'=>CRUDBooster::getCurrentModule()->name])}}</a></p>


### PR DESCRIPTION
Now, you can send return_url_label through a row action button as query string parametre so that detail view receives it and shows it at breadcrumb