### PR TITLE
Fix error Image::cache()

### DIFF
--- a/src/CRUDBoosterServiceProvider.php
+++ b/src/CRUDBoosterServiceProvider.php
@@ -62,7 +62,7 @@ class CRUDBoosterServiceProvider extends ServiceProvider
         $loader = AliasLoader::getInstance();
         $loader->alias('PDF', 'Barryvdh\DomPDF\Facade');
         $loader->alias('Excel', 'Maatwebsite\Excel\Facades\Excel');
-        $loader->alias('Image', 'Intervention\Image\Facades\Image');
+        $loader->alias('Image', 'Intervention\Image\ImageManagerStatic');
         $loader->alias('CRUDBooster', 'crocodicstudio\crudbooster\helpers\CRUDBooster');
         $loader->alias('CB', 'crocodicstudio\crudbooster\helpers\CB');
     }


### PR DESCRIPTION
Error when adding user in user management menu. And after changing the logo on the login page the logo doesn't appear
"crocodicstudio/crudbooster": "5.6.*",
"laravel/framework": "^8.40",