### PR TITLE
Fixing "Uncaught SyntaxError: Invalid or unexpected token"

### DIFF
--- a/src/views/default/table.blade.php
+++ b/src/views/default/table.blade.php
@@ -24,8 +24,7 @@
 
                 swal({
                         title: "{{cbLang("confirmation_title")}}",
-                        text: "{{cbLang("alert_bulk_action_button")}} " + title + " 
-			",
+                        text: "{{cbLang("alert_bulk_action_button")}} " + title + " ",
                         type: "warning",
                         showCancelButton: true,
                         confirmButtonColor: "#008D4C",


### PR DESCRIPTION
Removing the new line character that causes a syntax error in the browser console.