### PR TITLE
Fixing - before/after delete hooks

### DIFF
--- a/src/controllers/traits/ControllerSetting.php
+++ b/src/controllers/traits/ControllerSetting.php
@@ -143,6 +143,22 @@ trait ControllerSetting
     }
 
     /**
+     * @param Closure $callback
+     */
+    public function hookBeforeDelete(Closure $callback)
+    {
+        $this->data['hook_before_delete'] = $callback;
+    }
+
+    /**
+     * @param Closure $callback
+     */
+    public function hookAfterDelete(Closure $callback)
+    {
+        $this->data['hook_after_delete'] = $callback;
+    }
+
+    /**
      * @param Closure $callbackQuery
      */
     public function hookSearchQuery(Closure $callbackQuery)


### PR DESCRIPTION
With this PR, before and after delete hooks are added on ControllerSetting. All other actions seem to be covered but those related to deletion are missing.