### PR TITLE
FIX CBSeeder.php on php8

### DIFF
--- a/src/database/seeds/CBSeeder.php
+++ b/src/database/seeds/CBSeeder.php
@@ -1,4 +1,5 @@
 <?php
+namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;


### PR DESCRIPTION
fix CBSeeder does not exist php8 required namespace

<img width="1133" alt="Screen Shot 2022-02-08 at 13 56 47" src="https://user-images.githubusercontent.com/20250991/152927072-e60c9721-a270-44ca-9d2a-f2f8b2784900.png">
 