### PR TITLE
fix php artisan optimize error

### DIFF
--- a/src/database/seeders/CBSeeder.php
+++ b/src/database/seeders/CBSeeder.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace  Database\Seeders;
+
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;


### PR DESCRIPTION
when you run :
```
php artisan optimize
```

you get error:

 Whoops\Exception\ErrorException 

  Cannot declare class Database\Seeders\CBSeeder, because the name is already in use

  at vendor/crocodicstudio/crudbooster/src/database/seeds/CBSeeder.php:9
      5▕ use Illuminate\Database\Seeder;
      6▕ use Illuminate\Support\Facades\DB;
      7▕ use Illuminate\Support\Facades\Hash;
      8▕ 
  ➜   9▕ class CBSeeder extends Seeder
     10▕ {
     11▕     /**
     12▕      * Run the database seeds.
     13▕      *
